### PR TITLE
Add ctest

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,3 +18,7 @@ add_executable(pipeline
         test/main.cpp
         )
 target_include_directories(pipeline PRIVATE include)
+
+include(CTest)
+
+add_test (pipeline pipeline )


### PR DESCRIPTION
great little exercise!

Normal workflow with cmake for me is: 

$ make && ctest -V

So I added this possibility to the CMakeLists.txt

This also has the nice side effect of enabling tests in Visual Studio in RUN_TESTS

![image](https://user-images.githubusercontent.com/616409/92649347-28904000-f2eb-11ea-838a-301717b6b341.png)

